### PR TITLE
Solved problem with GitLab group id

### DIFF
--- a/src/com/capgemini/productionline/configuration/GitLab.groovy
+++ b/src/com/capgemini/productionline/configuration/GitLab.groovy
@@ -63,7 +63,7 @@ class GitLab implements Serializable {
     public String getGroupId(String groupname) {
         def searchresult = this.context.httpRequest consoleLogResponseBody: true, customHeaders: [[maskValue: true, name: 'PRIVATE-TOKEN', value: accesstoken]], httpMode: 'GET', url: "${gitlabHostUrl}/api/v4/groups?search=" + groupname
         def jsonObject = this.context.readJSON text: searchresult.getContent()
-        return String.valueOf(jsonObject.id).replace("[", "").replace("]", "")
+        return String.valueOf(jsonObject.id).replace("[", "").replace("]", "").split(',')[0].trim()
     }
 
     //Returns the project ID of a GIT project
@@ -71,7 +71,7 @@ class GitLab implements Serializable {
         def groupid = getGroupId(groupname)
         def searchresult = this.context.httpRequest consoleLogResponseBody: true, customHeaders: [[maskValue: true, name: 'PRIVATE-TOKEN', value: accesstoken]], httpMode: 'GET', url: "${gitlabHostUrl}/api/v4/groups/" + groupid + '/projects?search=' + projectname
         def jsonObject = this.context.readJSON text: searchresult.getContent()
-        return String.valueOf(jsonObject.id).replace("[", "").replace("]", "")
+        return String.valueOf(jsonObject.id).replace("[", "").replace("]", "").split(',')[0].trim()
     }
 
     //In order to create a group in Gitlab the user needs to have the "Can create groups permissions". This needs to be sex explicitely!


### PR DESCRIPTION
This PR solves  #31 

When the search group api call return more than one group, it will take always the first one which has the closest name to the search parameter.

The same behaviour when you search a project.